### PR TITLE
feature: Replace commonmark (deprecated) with markdown_it

### DIFF
--- a/manpageblog
+++ b/manpageblog
@@ -161,8 +161,9 @@ def read_content(filename):
     # Convert Markdown content to HTML.
     if filename.endswith(('.md', '.mkd', '.mkdn', '.mdown', '.markdown')):
         try:
-            import commonmark
-            text = commonmark.commonmark(text)
+            from markdown_it import MarkdownIt
+            md = MarkdownIt()
+            text = md.render(text)
         except ImportError as error:
             log('WARNING: Cannot render Markdown in {}: {}', filename, str(error))
 


### PR DESCRIPTION
feature: Replace commonmark (deprecated) with markdown_it

Replace  commonmark (deprecated) with markdown_it

Signed-off-by: Pratham Patel <prathampatel@thefossguy.com> (@thefossguy)
Fixes: #22