### PR TITLE
Change font and clean up the CSS(s)

### DIFF
--- a/_assets/css/dark.css
+++ b/_assets/css/dark.css
@@ -1,47 +1,9 @@
-body {
-    background-color: #000000;
+/* Theme: Dark */
+:root {
+    --main-text-color: #d3d3d3;
+    --main-bg-color: #000;
+    --links-color: #d3d3d3;
 }
 
-img {
-    max-width: 100%;
-    height: auto;
-  }
-
-  a:link, a:visited {
-      color: #d3d3d3;
-      text-decoration: underline dotted;
-  }
-
-  a:hover, a:active {
-      color: #d3d3d3;
-      text-decoration: underline dotted;
-  }
-
-  header section, footer section, manpage {
-      color: #d3d3d3;
-      font-size: 14px;
-      font-family: "Courier New", monospace;
-      margin-left: 0%;
-      max-width: 40em;
-  }
-
-  main, nav section, name section {
-      color: #d3d3d3;
-      max-width: 60em;
-      font-size: 14px;
-      font-family: "Courier New", monospace;
-      margin-left: 5%;
-      margin-right: auto;
-      padding: 0 0.5em;
-  }
-
-  code {
-      color: #d3d3d3;
-      max-width: 60em;
-      font-size: 14px;
-      font-style: italic;
-      font-family: "Courier New", monospace;
-      margin-left: 10%;
-      margin-right: auto;
-      padding: 0 0.5em;
-  }
+a:link, a:visited,
+a:hover, a:active { text-decoration: underline dotted !important; }

--- a/_assets/css/grey.css
+++ b/_assets/css/grey.css
@@ -1,47 +1,9 @@
-body {
-    background-color: #3d3d3d;
+/* Theme: Grey */
+:root {
+    --main-text-color: #d3d3d3;
+    --main-bg-color: #3d3d3d;
+    --links-color: #d3d3d3;
 }
 
-img {
-    max-width: 100%;
-    height: auto;
-  }
-
-  a:link, a:visited {
-      color: #d3d3d3;
-      text-decoration: underline dotted;
-  }
-
-  a:hover, a:active {
-      color: #d3d3d3;
-      text-decoration: underline dotted;
-  }
-
-  header section, footer section, manpage {
-      color: #d3d3d3;
-      font-size: 14px;
-      font-family: "Courier New", monospace;
-      margin-left: 0%;
-      max-width: 40em;
-  }
-
-  main, nav section, name section {
-      color: #d3d3d3;
-      max-width: 60em;
-      font-size: 14px;
-      font-family: "Courier New", monospace;
-      margin-left: 5%;
-      margin-right: auto;
-      padding: 0 0.5em;
-  }
-
-  code {
-      color: #d3d3d3;
-      max-width: 60em;
-      font-size: 14px;
-      font-style: italic;
-      font-family: "Courier New", monospace;
-      margin-left: 10%;
-      margin-right: auto;
-      padding: 0 0.5em;
-  }
+a:link, a:visited,
+a:hover, a:active { text-decoration: underline dotted !important; }

--- a/_assets/css/grey_blue.css
+++ b/_assets/css/grey_blue.css
@@ -1,47 +1,9 @@
-body {
-    background-color: #3d3d3d;
+/* Theme: Grey Blue */
+:root {
+    --main-text-color: #6082b6;
+    --main-bg-color: #3d3d3d;
+    --links-color: #6082b6;
 }
 
-img {
-    max-width: 100%;
-    height: auto;
-  }
-
-  a:link, a:visited {
-      color: #6082B6;
-      text-decoration: underline dotted;
-  }
-
-  a:hover, a:active {
-      color: #6082B6;
-      text-decoration: underline dotted;
-  }
-
-  header section, footer section, manpage {
-      color: #6082B6;
-      font-size: 14px;
-      font-family: "Courier New", monospace;
-      margin-left: 0%;
-      max-width: 40em;
-  }
-
-  main, nav section, name section {
-      color: #6082B6;
-      max-width: 60em;
-      font-size: 14px;
-      font-family: "Courier New", monospace;
-      margin-left: 5%;
-      margin-right: auto;
-      padding: 0 0.5em;
-  }
-
-  code {
-      color: #6082B6;
-      max-width: 60em;
-      font-size: 14px;
-      font-style: italic;
-      font-family: "Courier New", monospace;
-      margin-left: 10%;
-      margin-right: auto;
-      padding: 0 0.5em;
-  }
+a:link, a:visited,
+a:hover, a:active { text-decoration: underline dotted !important; }

--- a/_assets/css/light.css
+++ b/_assets/css/light.css
@@ -1,40 +1,6 @@
-img {
-    max-width: 100%;
-    height: auto;
-  }
- 
-  a:link, a:visited {
-      color: #6d6d6d;
-      text-decoration: none
-  }
- 
-  a:hover, a:active {
-      color: #6d6d6d;
-      text-decoration: underline
-  }
- 
-  header section, footer section, manpage {
-      font-size: 14px;
-      font-family: "Courier New", monospace;
-      margin-left: 0%;
-      max-width: 40em;
-  }
- 
-  main, nav section, name section {
-      max-width: 60em;
-      font-size: 14px;
-      font-family: "Courier New", monospace;
-      margin-left: 5%;
-      margin-right: auto;
-      padding: 0 0.5em;
-  }
-
-  code {
-      max-width: 60em;
-      font-size: 14px;
-      font-style: italic;
-      font-family: "Courier New", monospace;
-      margin-left: 10%;
-      margin-right: auto;
-      padding: 0 0.5em;
-  }
+/* Theme: Light (default theme) */
+:root {
+    --main-text-color: #333;
+    --main-bg-color: #fff;
+    --links-color: #6d6d6d;
+}

--- a/_assets/css/light_blue.css
+++ b/_assets/css/light_blue.css
@@ -1,0 +1,6 @@
+/* Theme: Light Blue */
+:root {
+    --main-text-color: #333;
+    --main-bg-color: whitesmoke; /* #f5f5f5 */
+    --links-color: cornflowerblue; /* #6495ed */
+}

--- a/_assets/css/manpageblog.css
+++ b/_assets/css/manpageblog.css
@@ -1,0 +1,41 @@
+/**
+ * Default CSS file for: manpageblog
+ * Fallback values: Light (default theme)
+ */
+body {
+    font: 300 normal 14px/1.25em monospace;
+    font-family: Menlo, 'DejaVu Sans Mono', Consolas, 'Liberation Mono', monospace;
+    color: var(--main-text-color, #333);
+    background: var(--main-bg-color, #fff);
+}
+
+a:link, a:visited {
+    color: var(--links-color, #6d6d6d);
+    text-decoration: none;
+}
+
+a:hover, a:active { text-decoration: underline; }
+
+a, b, strong { font-weight: 600; }
+
+img { max-width: 100%; height: auto; }
+
+header section, footer section, manpage {
+    max-width: 40em;
+    margin-left: 0%;
+}
+
+main, nav section, name section {
+    max-width: 60em;
+    margin-left: 5%;
+    margin-right: auto;
+    padding: 0 0.5em;
+}
+
+code {
+    font-style: italic;
+    max-width: 60em;
+    margin-left: 10%;
+    margin-right: auto;
+    padding: 0 0.5em;
+}

--- a/_templates/page.html
+++ b/_templates/page.html
@@ -20,6 +20,7 @@
     <meta name="robots" content="INDEX,FOLLOW">
     <meta name="generator" content="manpageblog {{ _version }}" />
     <link rel="stylesheet" type="text/css" href="{{ base_path }}/assets/css/{{ theme }}.css">
+    <link rel="stylesheet" type="text/css" href="{{ base_path }}/assets/css/manpageblog.css">
     <link rel="shortcut icon" type="image/png" href="{{ logo_favicon }}"/>
     <link rel="icon" type="image/png" href="{{ logo_favicon }}"/>
     <link rel="apple-touch-icon" href="{{ logo_apple_touch }}"/>

--- a/_templates/page_tags.html
+++ b/_templates/page_tags.html
@@ -20,6 +20,7 @@
     <meta name="robots" content="INDEX,FOLLOW">
     <meta name="generator" content="manpageblog {{ _version }}" />
     <link rel="stylesheet" type="text/css" href="{{ base_path }}/assets/css/{{ theme }}.css">
+    <link rel="stylesheet" type="text/css" href="{{ base_path }}/assets/css/manpageblog.css">
     <link rel="shortcut icon" type="image/png" href="{{ logo_favicon }}"/>
     <link rel="icon" type="image/png" href="{{ logo_favicon }}"/>
     <link rel="apple-touch-icon" href="{{ logo_apple_touch }}"/>


### PR DESCRIPTION
Since "Courier New" doesn't render well on the web, moving to a font-stack is to prefer. As discussed earlier, these fonts will serve well on all/most platforms. Also added the 'Liberation Mono' as it is a replacement font for Courier (V2) (ie. Courier New), and uses the same metrics.

The CSS have also been cleaned up a bit - removed some reduntant code, etc.

- Replace 'Courier New' with a fontstack, and move all fonts to body {}
- Use 1-liners where they fit to 1 line (< 80), and expand if not
- Use hex shortcodes when possible, like: #333 (#333333), #456 (#445566)

- - -

Use a main CSS file, and put the themes (just colors) in separate files. In that way, for any future style change to the design/layout there's only need to update one file, instead of 5+ files. For this layout/theme-separation - the use of CSS variables is really great. It's also easier when someone wants to add a theme or use a custom theme, and maybe gets behind on the updates.

- Add manpageblog.css (main css-file)
- Add corresponding link entries in: page{,_tags}.html
- Use CSS variables for color definitions, and set the fallback values to 'Light (default theme)'.
- Add theme: 'Light Blue', just like 'Grey' have a 'Grey Blue' version